### PR TITLE
LMSA-8279

### DIFF
--- a/src/main/java/edu/iu/uits/lms/lti/LTIConstants.java
+++ b/src/main/java/edu/iu/uits/lms/lti/LTIConstants.java
@@ -88,6 +88,7 @@ public class LTIConstants {
     public static final String CUSTOM_CANVAS_USER_ID_KEY = "canvas_user_id";
     public static final String CUSTOM_CANVAS_USER_LOGIN_ID_KEY = "canvas_user_login_id";
     public static final String CUSTOM_CANVAS_USER_SIS_ID_KEY = "canvas_user_sis_id";
+    public static final String CUSTOM_CANVAS_MEMBERSHIP_ROLES_KEY = "canvas_membership_roles";
 
     public static final String CUSTOM_CANVAS_COURSE_ID_VAL = "$Canvas.course.id";
     public static final String CUSTOM_CANVAS_USER_ID_VAL = "$Canvas.user.id";

--- a/src/main/java/edu/iu/uits/lms/lti/controller/OidcTokenAwareController.java
+++ b/src/main/java/edu/iu/uits/lms/lti/controller/OidcTokenAwareController.java
@@ -72,7 +72,8 @@ public class OidcTokenAwareController {
             token = (OidcAuthenticationToken) authToken;
 
             if (courseSessionService == null) {
-                String tokenContext = OidcTokenUtils.getCourseId(token);
+                OidcTokenUtils oidcTokenUtils = new OidcTokenUtils(token);
+                String tokenContext = oidcTokenUtils.getCourseId();
                 boolean contextMatch = context.equals(tokenContext);
 
                 if (! contextMatch) {

--- a/src/main/java/edu/iu/uits/lms/lti/controller/RedirectableLtiController.java
+++ b/src/main/java/edu/iu/uits/lms/lti/controller/RedirectableLtiController.java
@@ -55,12 +55,13 @@ public abstract class RedirectableLtiController extends OidcTokenAwareController
     */
    protected String performMacroVariableReplacement(String inputUrl) {
       OidcAuthenticationToken token = getTokenWithoutContext();
-      String canvasCourseId = OidcTokenUtils.getCourseId(token);
-      String userLoginId = OidcTokenUtils.getUserLoginId(token);
-      String sisUserId = OidcTokenUtils.getSisUserId(token);
-      String familyName = OidcTokenUtils.getPersonFamilyName(token);
-      String givenName = OidcTokenUtils.getPersonGivenName(token);
-      String[] roles = OidcTokenUtils.getRoles(token);
+      OidcTokenUtils oidcTokenUtils = new OidcTokenUtils(token);
+      String canvasCourseId = oidcTokenUtils.getCourseId();
+      String userLoginId = oidcTokenUtils.getUserLoginId();
+      String sisUserId = oidcTokenUtils.getSisUserId();
+      String familyName = oidcTokenUtils.getPersonFamilyName();
+      String givenName = oidcTokenUtils.getPersonGivenName();
+      String[] roles = oidcTokenUtils.getRoles();
 
       MacroVariableMapper macroVariableMapper = new MacroVariableMapper();
 

--- a/src/main/java/edu/iu/uits/lms/lti/service/LmsDefaultGrantedAuthoritiesMapper.java
+++ b/src/main/java/edu/iu/uits/lms/lti/service/LmsDefaultGrantedAuthoritiesMapper.java
@@ -33,21 +33,18 @@ package edu.iu.uits.lms.lti.service;
  * #L%
  */
 
-import com.nimbusds.jose.shaded.json.JSONArray;
 import edu.iu.uits.lms.lti.LTIConstants;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
-import uk.ac.ox.ctl.lti13.lti.Role;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
-import static uk.ac.ox.ctl.lti13.lti.Claims.ROLES;
-
+@Slf4j
 public class LmsDefaultGrantedAuthoritiesMapper implements GrantedAuthoritiesMapper {
    @Override
    public Collection<? extends GrantedAuthority> mapAuthorities(Collection<? extends GrantedAuthority> authorities) {
@@ -55,8 +52,9 @@ public class LmsDefaultGrantedAuthoritiesMapper implements GrantedAuthoritiesMap
       remappedAuthorities.addAll(authorities);
       for (GrantedAuthority authority: authorities) {
          OidcUserAuthority userAuth = (OidcUserAuthority) authority;
-         Map<String, Object> attributeMap = userAuth.getAttributes();
-         JSONArray roles = (JSONArray) attributeMap.get(ROLES);
+         OidcTokenUtils oidcTokenUtils = new OidcTokenUtils(userAuth.getAttributes());
+         log.debug("LTI Claims: {}", userAuth.getAttributes());
+         String[] roles = oidcTokenUtils.getCustomCanvasMembershipRoles();
          String newAuthString = returnEquivalentAuthority(roles, getDefaultInstructorRoles());
          OidcUserAuthority newUserAuth = new OidcUserAuthority(newAuthString, userAuth.getIdToken(), userAuth.getUserInfo());
 
@@ -74,9 +72,9 @@ public class LmsDefaultGrantedAuthoritiesMapper implements GrantedAuthoritiesMap
     * @param instructorRoles List of roles deemed as "Instructor" equivalents
     * @return Return the appropriate authority
     */
-   protected String returnEquivalentAuthority(JSONArray userRoles, List<String> instructorRoles) {
+   protected String returnEquivalentAuthority(String[] userRoles, List<String> instructorRoles) {
       for (String instructorRole : instructorRoles) {
-         if (userRoles.contains(instructorRole)) {
+         if (Arrays.asList(userRoles).contains(instructorRole)) {
             return LTIConstants.INSTRUCTOR_AUTHORITY;
          }
       }
@@ -84,8 +82,10 @@ public class LmsDefaultGrantedAuthoritiesMapper implements GrantedAuthoritiesMap
    }
 
    protected List<String> getDefaultInstructorRoles() {
-      return Arrays.asList(Role.System.ADMINISTRATOR, Role.System.ACCOUNT_ADMIN, Role.System.SYS_ADMIN,
-            Role.Institution.ADMINISTRATOR, Role.Institution.INSTRUCTOR, Role.Institution.FACULTY,
-            Role.Context.ADMINISTRATOR, Role.Context.INSTRUCTOR, "Instructor", "Administrator");
+//      return Arrays.asList(Role.System.ADMINISTRATOR, Role.System.ACCOUNT_ADMIN, Role.System.SYS_ADMIN,
+//            Role.Institution.ADMINISTRATOR, Role.Institution.INSTRUCTOR, Role.Institution.FACULTY,
+//            Role.Context.ADMINISTRATOR, Role.Context.INSTRUCTOR, "Instructor", "Administrator");
+
+      return Arrays.asList("TeacherEnrollment", "Account Admin", "Instructor", "Administrator");
    }
 }

--- a/src/main/java/edu/iu/uits/lms/lti/service/OidcTokenUtils.java
+++ b/src/main/java/edu/iu/uits/lms/lti/service/OidcTokenUtils.java
@@ -50,53 +50,69 @@ import static edu.iu.uits.lms.lti.LTIConstants.CUSTOM_CANVAS_USER_SIS_ID_KEY;
 
 public class OidcTokenUtils {
 
-   public static String getCourseId(OidcAuthenticationToken token) {
-      return getCustomValue(token, CUSTOM_CANVAS_COURSE_ID_KEY);
+   private Map<String, Object> attrMap;
+
+   /**
+    * Constructor to initialize using the token.  Will typically be used by tool controllers.
+    * @param token
+    */
+   public OidcTokenUtils(OidcAuthenticationToken token) {
+      this.attrMap = token.getPrincipal().getAttributes();
    }
 
-   public static String getUserId(OidcAuthenticationToken token) {
-      return getCustomValue(token, CUSTOM_CANVAS_USER_ID_KEY);
+   /**
+    * Constructor to initialize with an attribute map
+    * @param attributeMap
+    */
+   public OidcTokenUtils(Map<String, Object> attributeMap) {
+      this.attrMap = attributeMap;
    }
 
-   public static String getUserLoginId(OidcAuthenticationToken token) {
-      return getCustomValue(token, CUSTOM_CANVAS_USER_LOGIN_ID_KEY);
+   public String getCourseId() {
+      return getCustomValue(CUSTOM_CANVAS_COURSE_ID_KEY);
    }
 
-   public static String getSisUserId(OidcAuthenticationToken token) {
-      return getCustomValue(token, CUSTOM_CANVAS_USER_SIS_ID_KEY);
+   public String getUserId() {
+      return getCustomValue(CUSTOM_CANVAS_USER_ID_KEY);
    }
 
-   public static String getPersonFamilyName(OidcAuthenticationToken token) {
-      Map<String, Object> attrMap = getAttributes(token);
+   public String getUserLoginId() {
+      return getCustomValue(CUSTOM_CANVAS_USER_LOGIN_ID_KEY);
+   }
+
+   public String getSisUserId() {
+      return getCustomValue(CUSTOM_CANVAS_USER_SIS_ID_KEY);
+   }
+
+   public String getPersonFamilyName() {
       String name = (String) attrMap.get(CLAIMS_FAMILY_NAME_KEY);
       return name;
    }
 
-   public static String getPersonGivenName(OidcAuthenticationToken token) {
-      Map<String, Object> attrMap = getAttributes(token);
+   public String getPersonGivenName() {
       String name = (String) attrMap.get(CLAIMS_GIVEN_NAME_KEY);
       return name;
    }
 
-   public static String[] getRoles(OidcAuthenticationToken token) {
-      Map<String, Object> attrMap = getAttributes(token);
+   public String[] getRoles() {
       JSONArray jsonObj = (JSONArray) attrMap.get(Claims.ROLES);
       return jsonObj.toArray(String[]::new);
    }
 
-   public static String getPlatformGuid(OidcAuthenticationToken token) {
-      Map<String, Object> attrMap = getAttributes(token);
+   public String[] getCustomCanvasMembershipRoles() {
+      JSONObject jsonObj = (JSONObject) attrMap.get(Claims.CUSTOM);
+      String roleStr = jsonObj.getAsString("canvas_membership_roles");
+      return roleStr.split(",");
+   }
+
+   public String getPlatformGuid() {
       JSONObject jsonObj = (JSONObject) attrMap.get(Claims.PLATFORM_INSTANCE);
       return jsonObj.getAsString(CLAIMS_PLATFORM_GUID_KEY);
    }
 
-   public static String getCustomValue(OidcAuthenticationToken token, String key) {
-      Map<String, Object> attrMap = getAttributes(token);
+   public String getCustomValue(String key) {
       JSONObject jsonObj = (JSONObject) attrMap.get(Claims.CUSTOM);
       return jsonObj.getAsString(key);
    }
 
-   private static Map<String, Object> getAttributes(OidcAuthenticationToken token) {
-      return token.getPrincipal().getAttributes();
-   }
 }

--- a/src/main/java/edu/iu/uits/lms/lti/service/OidcTokenUtils.java
+++ b/src/main/java/edu/iu/uits/lms/lti/service/OidcTokenUtils.java
@@ -44,6 +44,7 @@ import static edu.iu.uits.lms.lti.LTIConstants.CLAIMS_FAMILY_NAME_KEY;
 import static edu.iu.uits.lms.lti.LTIConstants.CLAIMS_GIVEN_NAME_KEY;
 import static edu.iu.uits.lms.lti.LTIConstants.CLAIMS_PLATFORM_GUID_KEY;
 import static edu.iu.uits.lms.lti.LTIConstants.CUSTOM_CANVAS_COURSE_ID_KEY;
+import static edu.iu.uits.lms.lti.LTIConstants.CUSTOM_CANVAS_MEMBERSHIP_ROLES_KEY;
 import static edu.iu.uits.lms.lti.LTIConstants.CUSTOM_CANVAS_USER_ID_KEY;
 import static edu.iu.uits.lms.lti.LTIConstants.CUSTOM_CANVAS_USER_LOGIN_ID_KEY;
 import static edu.iu.uits.lms.lti.LTIConstants.CUSTOM_CANVAS_USER_SIS_ID_KEY;
@@ -101,7 +102,7 @@ public class OidcTokenUtils {
 
    public String[] getCustomCanvasMembershipRoles() {
       JSONObject jsonObj = (JSONObject) attrMap.get(Claims.CUSTOM);
-      String roleStr = jsonObj.getAsString("canvas_membership_roles");
+      String roleStr = jsonObj.getAsString(CUSTOM_CANVAS_MEMBERSHIP_ROLES_KEY);
       return roleStr.split(",");
    }
 


### PR DESCRIPTION
Get role information from a custom field instead of the native "roles" claim, as it has less helpful things in there!  Such as since TA is a sub-role of instructor, instructor comes through as well, even though the user isn't an instructor.